### PR TITLE
Add CloudFlare External Cache Service

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[**.php]
+indent_style = tab
+indent_size = 4

--- a/cachemonster/config.php
+++ b/cachemonster/config.php
@@ -9,10 +9,15 @@ return array(
 	// Template caches options
 	'includeQueryString' => true, // Set to false to stop including the query string in the stored path
 
-	// External service settings - so far only Varnish supported so this is pretty specific to that
-	'externalCachingService' => false, // Can be 'Varnish' or false
+	// External service settings - so far only Varnish and CloudFlare supported
+	'externalCachingService' => false, // Varnish, CloudFlare, or false
+
 	'externalCachingServiceSettings' => array(
-		'url' => CRAFT_SITE_URL
+		'url' => CRAFT_SITE_URL,
+		// the following external settings are specific to at least CloudFlare
+		'authEmail' => null
+		'authKey' => null
+		'zoneId' => null
 	),
 
 	// Warming settings

--- a/cachemonster/config.php
+++ b/cachemonster/config.php
@@ -15,8 +15,8 @@ return array(
 	'externalCachingServiceSettings' => array(
 		'url' => CRAFT_SITE_URL,
 		// the following external settings are specific to at least CloudFlare
-		'authEmail' => null
-		'authKey' => null
+		'authEmail' => null,
+		'authKey' => null,
 		'zoneId' => null
 	),
 

--- a/cachemonster/services/CacheMonster_ExternalCloudFlareService.php
+++ b/cachemonster/services/CacheMonster_ExternalCloudFlareService.php
@@ -1,0 +1,102 @@
+<?php
+namespace Craft;
+
+/**
+ * Class CacheMonster_ExternalCloudFlareService
+ *
+ * @package   CacheMonster
+ * @author    Josh Angell, Solomon Hawk
+ * @copyright Copyright (c) 2016, Supercool Ltd
+ * @link      http://plugins.supercooldesign.co.uk
+ */
+
+class CacheMonster_ExternalCloudFlareService extends BaseApplicationComponent implements ICacheMonster_External
+{
+	/**
+	 * @var string
+	 */
+	private static $_cloudFlareApiBaseUrl = 'https://api.cloudflare.com/client/v4/zones/';
+
+	/**
+	 * Purges the given paths
+	 *
+	 * @param array $paths An array of paths to purge
+	 *
+	 * @return bool
+	 */
+	public function purgePaths($paths=array())
+	{
+		if (!$this->_hasValidSettings())
+		{
+			throw new Exception(Craft::t('Could not validate the CloudFlare cache settings! Please ensure you have entered an "authEmail", "authKey" and "zoneId".'));
+		}
+
+		$settings = craft()->config->get('externalCachingServiceSettings', 'cacheMonster');
+
+		// Normalize the paths returned from Craft's cache table
+		// by removing "site:"" and appending the site url
+		$preparedPaths = $this->_preparePaths($paths);
+
+		// Make the client
+		$client = new \Guzzle\Http\Client();
+
+		// Set the relevant headers
+		$client->setDefaultOption('headers', array(
+			'X-Auth-Email' => $settings['authEmail'],
+			'X-Auth-Key'   => $settings['authKey'],
+			'Content-Type' => 'application/json'
+		));
+
+		try
+		{
+			// Issue a DELETE request to the purge endpoint passing
+			// along the list of files to be purged
+			$url = $this->_purgeUrlForZone($settings['zoneId']);
+			$body = json_encode(array('files' => $preparedPaths));
+			$request = $client->delete($url);
+			$request->setBody($body);
+			$request->send();
+		}
+		catch (\Exception $e)
+		{
+			CacheMonsterPlugin::log('An exception occurred: '.$e->getMessage(), LogLevel::Error);
+			return false;
+		}
+
+		// Just pretend it always worked
+		return true;
+	}
+
+	// Private
+
+	/**
+	 * @param string $zoneId
+	 */
+	private function _purgeUrlForZone($zoneId)
+	{
+		return static::$_cloudFlareApiBaseUrl . $zoneId . '/purge_cache';
+	}
+
+	private function _hasValidSettings()
+	{
+		$settings = craft()->config->get('externalCachingServiceSettings', 'cacheMonster');
+
+		return $settings['authEmail'] != "" && $settings['authKey'] != "" && $settings['zoneId'];
+	}
+
+	/**
+	 * @param array $paths
+	 */
+	private function _preparePaths($paths=array())
+	{
+		$preparedPaths = array();
+
+		foreach ($paths as $path)
+		{
+			$newPath = preg_replace('/site:/', '', $path, 1);
+			$preparedPaths[] = UrlHelper::getSiteUrl($newPath);
+		}
+
+		return $preparedPaths;
+	}
+}


### PR DESCRIPTION
Feel free to mandate any and all changes you'd like to see.

I added a `.editorconfig` file to the root with rules for `.php` files - let me know if these are incorrect as far as your preferences go.

Though I have it as a static string constant here, it seems like the CloudFlare base API URL should also be configurable. What do you think?
